### PR TITLE
Add squad command for AGENTS generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ make build-all
 
 **That's it!** No Docker, no complex setup, no cloud accounts needed.
 
+### CLI: Generate AI Squad
+
+Use the `squad` command to generate an `AGENTS.md` with recommended AI agents based on your project requirements:
+
+```bash
+./grompt squad "Quero um microserviço de backend para pagamentos, com autenticação, integração com Stripe, testes automatizados, e deploy em Docker. Prefiro Go ou Python, sem Java."
+```
+
+This will create an `AGENTS.md` file in the current directory.
+
 ---
 
 ## 💡 **Usage Examples**

--- a/cmd/cli/squad.go
+++ b/cmd/cli/squad.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rafa-mori/grompt/internal/services/squad"
+)
+
+func SquadCmdList() []*cobra.Command {
+	return []*cobra.Command{
+		generateSquad(),
+	}
+}
+
+func generateSquad() *cobra.Command {
+	var outPath string
+	cmd := &cobra.Command{
+		Use:   "squad [requirements]",
+		Short: "Generate AGENTS.md from free text requirements",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req := args[0]
+			if outPath == "" {
+				outPath = "AGENTS.md"
+			}
+			md, err := squad.BuildAndSave(req, outPath)
+			if err != nil {
+				return err
+			}
+			fmt.Println(md)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&outPath, "output", "o", "AGENTS.md", "Output file path")
+
+	return cmd
+}

--- a/cmd/wrpr.go
+++ b/cmd/wrpr.go
@@ -58,6 +58,7 @@ func (m *Grompt) Command() *cobra.Command {
 	}
 
 	rtCmd.AddCommand(cc.ServerCmdList()...)
+	rtCmd.AddCommand(cc.SquadCmdList()...)
 	rtCmd.AddCommand(vs.CliCommand())
 
 	// Set usage definitions for the command and its subcommands

--- a/internal/services/squad/squad.go
+++ b/internal/services/squad/squad.go
@@ -1,0 +1,129 @@
+package squad
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// Agent represents an AI agent specification for AGENTS.md
+// Each agent has a title, role description, skills, restrictions and a prompt example.
+type Agent struct {
+	Title         string
+	Role          string
+	Skills        []string
+	Restrictions  []string
+	PromptExample string
+}
+
+// ParseRequirements parses a free text requirement string and returns a slice of Agent definitions.
+// The parsing uses a simple heuristic based on keywords.
+func ParseRequirements(req string) []Agent {
+	lower := strings.ToLower(req)
+	agents := []Agent{}
+
+	langs := []string{}
+	langPrefs := map[string]bool{}
+
+	for _, lang := range []string{"go", "python", "javascript", "typescript", "java", "rust", "ruby"} {
+		if strings.Contains(lower, lang) {
+			langs = append(langs, strings.Title(lang))
+			langPrefs[lang] = true
+		}
+	}
+
+	restricts := []string{}
+	rJava := regexp.MustCompile(`(?i)(sem|without|no)\s+java`)
+	if rJava.MatchString(lower) {
+		restricts = append(restricts, "No Java")
+	}
+
+	if strings.Contains(lower, "backend") || strings.Contains(lower, "microservi") || strings.Contains(lower, "api") {
+		title := "Backend Developer"
+		if len(langs) > 0 {
+			title += " (" + strings.Join(langs, "/") + ")"
+		}
+		agents = append(agents, Agent{
+			Title:         title,
+			Role:          "Implement backend services",
+			Skills:        append([]string{"REST"}, langs...),
+			Restrictions:  restricts,
+			PromptExample: "Design and implement backend APIs following the requirements.",
+		})
+	}
+
+	if strings.Contains(lower, "docker") || strings.Contains(lower, "deploy") || strings.Contains(lower, "ci/cd") || strings.Contains(lower, "kubernetes") {
+		agents = append(agents, Agent{
+			Title:         "DevOps Engineer",
+			Role:          "Setup Docker and CI/CD pipelines",
+			Skills:        []string{"Docker", "CI/CD", "Cloud"},
+			PromptExample: "Configure Docker containers and deployment pipeline.",
+		})
+	}
+
+	if strings.Contains(lower, "test") || strings.Contains(lower, "qa") {
+		skills := []string{"Automated Testing"}
+		if langPrefs["go"] {
+			skills = append(skills, "go test")
+		}
+		if langPrefs["python"] {
+			skills = append(skills, "pytest")
+		}
+		agents = append(agents, Agent{
+			Title:         "QA Engineer",
+			Role:          "Write and execute automated tests",
+			Skills:        skills,
+			PromptExample: "Create test suites ensuring high coverage.",
+		})
+	}
+
+	if len(agents) == 0 {
+		agents = append(agents, Agent{
+			Title:         "Software Engineer",
+			Role:          "Implement requested features",
+			Skills:        langs,
+			Restrictions:  restricts,
+			PromptExample: "Develop the project according to the requirements.",
+		})
+	}
+
+	return agents
+}
+
+// GenerateMarkdown creates the AGENTS.md content based on agents slice.
+func GenerateMarkdown(agents []Agent) string {
+	b := &strings.Builder{}
+	b.WriteString("# Agents\n\n")
+	for _, a := range agents {
+		b.WriteString("## " + a.Title + "\n")
+		if a.Role != "" {
+			b.WriteString("- Role: " + a.Role + "\n")
+		}
+		if len(a.Skills) > 0 {
+			b.WriteString("- Skills: " + strings.Join(a.Skills, ", ") + "\n")
+		}
+		if len(a.Restrictions) > 0 {
+			b.WriteString("- Restrictions: " + strings.Join(a.Restrictions, ", ") + "\n")
+		}
+		if a.PromptExample != "" {
+			b.WriteString("- Prompt Example: " + a.PromptExample + "\n")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// WriteFile writes the AGENTS.md content to the provided path.
+func WriteFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// BuildAndSave generates the agents from requirements and writes AGENTS.md at path.
+func BuildAndSave(req, path string) (string, error) {
+	agents := ParseRequirements(req)
+	md := GenerateMarkdown(agents)
+	if err := WriteFile(path, md); err != nil {
+		return "", err
+	}
+	return md, nil
+}


### PR DESCRIPTION
This pull request introduces a new CLI command, `squad`, which generates an `AGENTS.md` file based on free-text project requirements. The changes include implementing the command, integrating it into the CLI, and adding functionality to parse requirements and generate markdown content for AI agents.

### New CLI Command: Squad

* **README Update**: Documented the `squad` command usage, including an example of generating an `AGENTS.md` file based on project requirements. (`README.md`, [README.mdR106-R115](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R115))
* **Command Implementation**: Added the `squad` command to the CLI, which accepts free-text requirements, parses them, and generates an `AGENTS.md` file. (`cmd/cli/squad.go`, [cmd/cli/squad.goR1-R40](diffhunk://#diff-180834baaf746a1dbede19195bbd3c428dc28391f82d4093da5f2336122115c7R1-R40))
* **CLI Integration**: Integrated the `squad` command into the main CLI by adding it to the list of available commands. (`cmd/wrpr.go`, [cmd/wrpr.goR61](diffhunk://#diff-be688e8b7cb9251850d8808b198a2a7bf7324a81ab15a5458f5832444d711672R61))

### Functionality for Parsing Requirements and Generating Markdown

* **Agent Parsing**: Implemented `ParseRequirements` to extract agent specifications from free-text requirements using heuristics based on keywords. (`internal/services/squad/squad.go`, [internal/services/squad/squad.goR1-R129](diffhunk://#diff-d7a30a95fe763b31820286a73f6b44cd99b257c1273bd96ad48b4f0485750d66R1-R129))
* **Markdown Generation**: Added functions to generate markdown content (`GenerateMarkdown`) and write it to a file (`WriteFile`), enabling the creation of `AGENTS.md`. (`internal/services/squad/squad.go`, [internal/services/squad/squad.goR1-R129](diffhunk://#diff-d7a30a95fe763b31820286a73f6b44cd99b257c1273bd96ad48b4f0485750d66R1-R129))