### PR TITLE
fix: Corrigir versão do aplicativo para 1.0.1 no manifest.json

### DIFF
--- a/internal/module/info/manifest.json
+++ b/internal/module/info/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Kubex - Grompt",
   "application": "grompt",
-  "version": "1.2.1",
+  "version": "1.0.1",
   "private": false,
   "published": true,
   "aliases": [


### PR DESCRIPTION
This pull request makes a minor update to the `internal/module/info/manifest.json` file, reverting the `version` field from `1.2.1` back to `1.0.1`.